### PR TITLE
Fix profile mod install/update issues

### DIFF
--- a/Rumble Mod Manager/ProfileSystem.cs
+++ b/Rumble Mod Manager/ProfileSystem.cs
@@ -67,18 +67,27 @@ namespace Rumble_Mod_Manager
 
         public static void ApplyProfile(ModProfile profile)
         {
+            var previousProfile = CurrentProfile;
             CurrentProfile = profile;
 
             Directory.CreateDirectory(ModsDirectory);
             Directory.CreateDirectory(ModCacheDirectory);
 
-            foreach (string modId in CurrentProfile.EnabledModIds)
+            if (previousProfile != null)
             {
-                string sourcePath = Path.Combine(ModsDirectory, modId + ".dll");
-                string targetPath = Path.Combine(ModCacheDirectory, modId + ".dll");
+                foreach (string modId in previousProfile.EnabledModIds)
+                {
+                    string sourcePath = Path.Combine(ModsDirectory, modId + ".dll");
+                    string targetPath = Path.Combine(ModCacheDirectory, modId + ".dll");
 
-                if (File.Exists(sourcePath))
-                    File.Move(sourcePath, targetPath);
+                    if (File.Exists(sourcePath))
+                    {
+                        if (File.Exists(targetPath))
+                            File.Delete(targetPath);
+
+                        File.Move(sourcePath, targetPath);
+                    }
+                }
             }
 
             foreach (string modId in profile.EnabledModIds)
@@ -87,7 +96,12 @@ namespace Rumble_Mod_Manager
                 string target = Path.Combine(ModsDirectory, modId + ".dll");
 
                 if (File.Exists(source))
+                {
+                    if (File.Exists(target))
+                        File.Delete(target);
+
                     File.Move(source, target);
+                }
             }
 
             Properties.Settings.Default.LastLoadedProfile = profile.Name;

--- a/Rumble Mod Manager/Settings.cs
+++ b/Rumble Mod Manager/Settings.cs
@@ -62,11 +62,7 @@ namespace Rumble_Mod_Manager
 
             if (ModMangager != null)
             {
-                string profilePath = Path.Combine(Properties.Settings.Default.RumblePath, "Mod_Profiles", $"{Properties.Settings.Default.LastLoadedProfile}_profile.json");
-                string json = File.ReadAllText(profilePath);
-                var profile = JsonConvert.DeserializeObject<ModProfile>(json);
-
-                ModMangager.LoadMods(profile);
+                ModMangager.LoadMods(ProfileSystem.CurrentProfile);
             }
             else if (launchPage != null)
             {

--- a/Rumble Mod Manager/ThunderstoreMods.cs
+++ b/Rumble Mod Manager/ThunderstoreMods.cs
@@ -172,11 +172,16 @@ namespace Rumble_Mod_Manager
                 }
             }
 
-            if (!profile.EnabledModIds.Contains(modId) && !profile.DisabledModIds.Contains(modId))
+            if (modEnabled)
             {
-                if (modEnabled)
+                profile.DisabledModIds.Remove(modId);
+                if (!profile.EnabledModIds.Contains(modId))
                     profile.EnabledModIds.Add(modId);
-                else
+            }
+            else
+            {
+                profile.EnabledModIds.Remove(modId);
+                if (!profile.DisabledModIds.Contains(modId))
                     profile.DisabledModIds.Add(modId);
             }
         }
@@ -274,11 +279,7 @@ namespace Rumble_Mod_Manager
                     installingMessage?.UpdateStatusMessage($"'{mod.Name}' successfully installed");
                     installingMessage?.ShowButtons(true);
 
-                    string profilePath = Path.Combine(Properties.Settings.Default.RumblePath, "Mod_Profiles", $"{Properties.Settings.Default.LastLoadedProfile}_profile.json");
-                    string json = File.ReadAllText(profilePath);
-                    var profile = JsonConvert.DeserializeObject<ModProfile>(json);
-
-                    form1.LoadMods(profile);
+                    form1.LoadMods(ProfileSystem.CurrentProfile);
                 }
             }
             catch (Exception ex)
@@ -370,12 +371,15 @@ namespace Rumble_Mod_Manager
                         string modsPath = Path.Combine(modsFolder, Path.GetFileName(dllFilePath));
                         File.Copy(cachePath, modsPath, overwrite: true);
 
+                        ProfileSystem.CurrentProfile.DisabledModIds.Remove(modId);
                         if (!ProfileSystem.CurrentProfile.EnabledModIds.Contains(modId))
                             ProfileSystem.CurrentProfile.EnabledModIds.Add(modId);
-                    } else
+                    }
+                    else
                     {
-                        if (!ProfileSystem.CurrentProfile.EnabledModIds.Contains(modId))
-                            ProfileSystem.CurrentProfile.EnabledModIds.Add(modId);
+                        ProfileSystem.CurrentProfile.EnabledModIds.Remove(modId);
+                        if (!ProfileSystem.CurrentProfile.DisabledModIds.Contains(modId))
+                            ProfileSystem.CurrentProfile.DisabledModIds.Add(modId);
                     }
 
                     ProfileSystem.SaveProfile(ProfileSystem.CurrentProfile);


### PR DESCRIPTION
## Summary
- fix profile switching not moving mods correctly
- ensure install/enable logic keeps profile lists in sync
- refresh mod list after online install
- update settings reload logic

## Testing
- `dotnet build 'Rumble Mod Manager.sln' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f436ed2288328a516a96bd3585161